### PR TITLE
Added 'help2man' to the list of apt packages, also removed stray newline

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,7 @@ deb-src http://deb.debian.org/debian bullseye-backports main contrib non-free
 4. Now, install some packages using the usual package manager.
 
 ```
-apt install git gcc-13 g++-13 make libgmp-dev libmpfr-dev texinfo bison flex wget lzip xz-utils zlib1g-dev curl automake cmake autopoint libtool unzip bzip2 meson pkg-config gettext subversion
-yasm nasm libtool-bin mm-common python-is-python3 libglib2.0-dev-bin libxml2-utils autoconf-archive gperf libglib2.0-dev gtk-doc-tools gtk-update-icon-cache python3-requests zip qt6-base-dev qt6-shadertools-dev qt6-tools-dev nsis
+apt install git gcc-13 g++-13 make libgmp-dev libmpfr-dev texinfo bison flex wget lzip xz-utils zlib1g-dev curl automake cmake autopoint libtool unzip bzip2 meson pkg-config gettext subversion yasm nasm libtool-bin mm-common python-is-python3 libglib2.0-dev-bin libxml2-utils autoconf-archive gperf libglib2.0-dev gtk-doc-tools gtk-update-icon-cache python3-requests zip qt6-base-dev qt6-shadertools-dev qt6-tools-dev nsis help2man
 ```
 
 5. Clone my package from git (see the address at the top of this page).


### PR DESCRIPTION
Added `help2man` to the list of apt packages to install after a build failed from not having it. Took the liberty of also removing the same codebox's stray newline.

Enviornment is a fresh Debian install running under Win11 WSL2 created specifically for building the tools. Will followup with additional PRs if the build reports more missing programs, and will also report on success when/if it occurs.

```
Oct 30 08:55:22 make[1]: Entering directory '/mnt/f/Projects/ffmpeg/MultimediaTools-mingw-w64/sandbox/x86_64/libtool-2.5.4'
Oct 30 08:55:22 Making all in .
Oct 30 08:55:22 make[2]: Entering directory '/mnt/f/Projects/ffmpeg/MultimediaTools-mingw-w64/sandbox/x86_64/libtool-2.5.4'
Oct 30 08:55:22   GEN      doc/libtool.1
Oct 30 08:55:22 /mnt/f/Projects/ffmpeg/MultimediaTools-mingw-w64/sandbox/x86_64/libtool-2.5.4/build-aux/missing: line 85: help2man: command not found
Oct 30 08:55:22 WARNING: 'help2man' is missing on your system.
Oct 30 08:55:22          You should only need it if you modified a dependency of a man page.
Oct 30 08:55:22          You may want to install the GNU Help2man package:
Oct 30 08:55:22          <https://www.gnu.org/software/help2man/>
Oct 30 08:55:22 make[2]: *** [Makefile:2431: doc/libtool.1] Error 127
Oct 30 08:55:22 make[2]: *** Waiting for unfinished jobs....
Oct 30 08:55:22 make[3]: Entering directory '/mnt/f/Projects/ffmpeg/MultimediaTools-mingw-w64/sandbox/x86_64/libtool-2.5.4'
Oct 30 08:55:22 make[3]: Leaving directory '/mnt/f/Projects/ffmpeg/MultimediaTools-mingw-w64/sandbox/x86_64/libtool-2.5.4'
Oct 30 08:55:22 make[2]: Leaving directory '/mnt/f/Projects/ffmpeg/MultimediaTools-mingw-w64/sandbox/x86_64/libtool-2.5.4'
Oct 30 08:55:22 make[1]: *** [Makefile:1651: all-recursive] Error 1
Oct 30 08:55:22 make[1]: Leaving directory '/mnt/f/Projects/ffmpeg/MultimediaTools-mingw-w64/sandbox/x86_64/libtool-2.5.4'
Oct 30 08:55:22 make: *** [Makefile:1033: all] Error 2
Oct 30 08:55:22 Build failure. Please see error messages above.
```